### PR TITLE
[Pba 2553] Loading spinner not shown after IMA mid rolls

### DIFF
--- a/sdk/OoyalaSkinSDK/index.ios.js
+++ b/sdk/OoyalaSkinSDK/index.ios.js
@@ -45,7 +45,7 @@ var OoyalaSkin = React.createClass({
       // states from native
       title: '',
       description: '',
-      promoUrl: '', 
+      promoUrl: '',
       hostedAtUrl: '',
       playhead: 0,
       duration: 1,
@@ -65,7 +65,7 @@ var OoyalaSkin = React.createClass({
     };
   },
 
-  onOptionButtonPress: function(buttonName) { 
+  onOptionButtonPress: function(buttonName) {
     this.setState({buttonSelected:buttonName, screenType:SCREEN_TYPES.MOREOPTION_SCREEN});
   },
 
@@ -83,9 +83,9 @@ var OoyalaSkin = React.createClass({
 
   pauseOnOptions: function() {
     if (this.state.screenType != SCREEN_TYPES.MOREOPTION_SCREEN) {
-      this.previousScreenType = this.state.screenType; 
+      this.previousScreenType = this.state.screenType;
     }
-    
+
     if (this.state.rate > 0) {
       this.setState({pausedByOverlay:true});
       eventBridge.onPress({name:BUTTON_NAMES.PLAY_PAUSE});
@@ -153,6 +153,7 @@ var OoyalaSkin = React.createClass({
       playhead: e.playhead,
       duration: e.duration,
       availableClosedCaptionsLanguages: e.availableClosedCaptionsLanguages,
+      rate: e.rate
     });
 
     if(this.state.screenType == SCREEN_TYPES.VIDEO_SCREEN || this.state.screenType == SCREEN_TYPES.END_SCREEN){
@@ -179,13 +180,13 @@ var OoyalaSkin = React.createClass({
   onCurrentItemChange: function(e) {
     console.log("currentItemChangeReceived, promoUrl is " + e.promoUrl);
     this.setState({
-      title:e.title, 
-      description:e.description, 
-      duration:e.duration, 
+      title:e.title,
+      description:e.description,
+      duration:e.duration,
       live:e.live,
-      promoUrl:e.promoUrl, 
+      promoUrl:e.promoUrl,
       hostedAtUrl: e.hostedAtUrl,
-      width:e.width, 
+      width:e.width,
       height:e.height});
     if (!this.state.autoPlay) {
       this.setState({screenType: SCREEN_TYPES.START_SCREEN});
@@ -211,11 +212,11 @@ var OoyalaSkin = React.createClass({
   },
 
   onStateChange: function(e) {
-    console.log("state changed")
+    console.log("state changed: " + e.state);
     switch (e.state) {
       case "paused": this.setState({rate:0}); break;
-      case "playing": 
-        this.setState({rate:1}); 
+      case "playing":
+        this.setState({rate:1});
         this.setState({screenType: SCREEN_TYPES.VIDEO_SCREEN});
         break;
       default: break;
@@ -239,7 +240,7 @@ var OoyalaSkin = React.createClass({
     console.log('onLanguageSelected:'+e);
     this.setState({selectedLanguage:e});
   },
-  
+
   shouldShowLandscape: function() {
     return this.state.width > this.state.height;
   },
@@ -328,7 +329,7 @@ var OoyalaSkin = React.createClass({
         discoveryPanel={this._renderDiscoveryPanel()}
         description={this.state.description}
         promoUrl={this.state.promoUrl}
-        duration={this.state.duration} 
+        duration={this.state.duration}
         onPress={(name) => this.handlePress(name)}
         onSocialButtonPress={(socialType) => this.onSocialButtonPress(socialType)}/>
     );
@@ -418,7 +419,7 @@ var OoyalaSkin = React.createClass({
     if (!this.state.discoveryResults) {
       return null;
     }
-    
+
     return (
       <DiscoveryPanel
         config={this.props.discoveryScreen}
@@ -432,7 +433,7 @@ var OoyalaSkin = React.createClass({
   _renderMoreOptionPanel: function() {
     console.log("renderMoreOptionPanel:"+ this.state.buttonSelected);
     switch (this.state.buttonSelected) {
-      case BUTTON_NAMES.DISCOVERY: 
+      case BUTTON_NAMES.DISCOVERY:
         return this._renderDiscoveryPanel();
         break;
       case BUTTON_NAMES.QUALITY:

--- a/sdk/OoyalaSkinSDK/widgets/VideoViewPlayPause.js
+++ b/sdk/OoyalaSkinSDK/widgets/VideoViewPlayPause.js
@@ -132,7 +132,7 @@ var VideoViewPlayPause = React.createClass({
   },
 
   _renderLoading: function() {
-    if((this.props.rate <= 0 || this.props.playhead == 0) && !this.props.showButton && !this.state.controlPlaying) {
+    if(this.props.playhead == 0 && !this.props.showButton && !this.state.controlPlaying) {
       return (
         <View style={styles.loading}>
           <ActivityIndicatorIOS


### PR DESCRIPTION
Do we really need to have the rate in the if condition for the _renderLoading function (of VideoViewPlayPause.js)?

If I remove it, the problem is fixed, as I update the 'rate' everytime we get an onTimeChanged notification from the player, but the 'rate' is always 0 for the player when the ads are playing. I don't know if this is correct, but if I leave rate in the if condition in _renderLoading, then the loading spinner shows when ads are playing, which get us a new bug.

So, what do you think?